### PR TITLE
Fixed error in command for starting API server

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,5 +15,5 @@ and interacting with the Sovrin Distributed Identity Ledger.
 - `$ pip install -r requirements.txt`
 
 ## Steps to run api
-- `$ python -m agent.scripts.startApiServer.py 0.0.0.0 8080`
+- `$ python -m scripts.startApiServer 0.0.0.0 8080`
 - Run `$ pytest` to run all tests


### PR DESCRIPTION
Presently, `scripts` folder is outside `agent`, and .py extension should be omitted in the command (`startApiServer` file should have a .py extension though)